### PR TITLE
Link directly to commit reference on Github

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ layout: default
 {{- "|" -}}
 <span class="status-{{ status.windows }}">{{ status.windows | replace: '-', ' ' }}</span>
 {{- "|" -}}
-<a href="https://github.com/rust-lang/rust/commits/{{ status.commit }}">{{ status.commit | truncate: 9, "" }}</a> on <date datetime="{{ status.datetime }}">{{ status.datetime | date: "%Y-%m-%d %H:%M:%S" }}</date> |
+<a href="https://github.com/rust-lang/rust/commit/{{ status.commit }}">{{ status.commit | truncate: 9, "" }}</a> on <date datetime="{{ status.datetime }}">{{ status.datetime | date: "%Y-%m-%d %H:%M:%S" }}</date> |
 {%- endfor %}
 
 The table above reflects the real-time status on the master branch. 


### PR DESCRIPTION
Using `github.com/user/repo/commits/<sha>` shows a list of commits, starting at the specified commit. By using `github.com/user/repo/commit/<sha>`, we can link directly to the diff for the commit in question.