### PR TITLE
Update a link to rustup components history

### DIFF
--- a/index.md
+++ b/index.md
@@ -15,4 +15,4 @@ layout: default
 {%- endfor %}
 
 The table above reflects the real-time status on the master branch. 
-Please also check <https://mexus.github.io/rustup-components-history/> for availability of each component on nightly.
+Please also check <https://rust-lang.github.io/rustup-components-history/> for availability of each component on nightly.


### PR DESCRIPTION
The *rustup-components-history* tool's repo has migrated to [rust-lang/rustup-components-history](https://github.com/rust-lang/rustup-components-history) and the website to [rust-lang.github.io](https://rust-lang.github.io/rustup-components-history/) respectively