### PR TITLE
Remove the deprecated rustc-guide entry.

### DIFF
--- a/_data/latest.json
+++ b/_data/latest.json
@@ -70,13 +70,6 @@
         "datetime": "2019-05-24T03:07:40Z"
     },
     {
-        "tool": "rustc-guide",
-        "windows": "test-pass",
-        "linux": "test-fail",
-        "commit": "21ed50522ddb998f5367229984a4510af578899f",
-        "datetime": "2020-02-14T04:51:15Z"
-    },
-    {
         "tool": "rustc-dev-guide",
         "windows": "test-pass",
         "linux": "test-fail",


### PR DESCRIPTION
I'm not sure whether this can land now, but let me put the PR here first.

cc @kennytm @spastorino 