### PR TITLE
Remove clippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ bundled with the Rust build system.
 
 The latest status can be read from https://rust-lang-nursery.github.io/rust-toolstate/.
 
-Currently these four tools are tracked:
+Currently these tools are tracked:
 
-* [clippy](https://github.com/rust-lang/rust-clippy)
 * [miri](https://github.com/rust-lang/miri)
 * [rls](https://github.com/rust-lang/rls)
 * [rustfmt](https://github.com/rust-lang/rustfmt)
+* All the external books
 
 These tools can be in one of the following states:
 

--- a/_data/latest.json
+++ b/_data/latest.json
@@ -1,12 +1,5 @@
 [
     {
-        "tool": "clippy-driver",
-        "windows": "test-fail",
-        "linux": "test-fail",
-        "commit": "53d3bc02ed90eba01c5dbc5b2d0c4cabb67ffb4d",
-        "datetime": "2020-05-02T16:26:19Z"
-    },
-    {
         "tool": "miri",
         "windows": "test-pass",
         "linux": "test-pass",


### PR DESCRIPTION
Clippy is now required as of https://github.com/rust-lang/rust/pull/70655 and https://github.com/rust-lang/rust/pull/73285. Its status is no longer published. This removes the permanently stuck "test-fail" status entry.

Closes #19