### PR TITLE
Remove rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Currently these tools are tracked:
 
 * [miri](https://github.com/rust-lang/miri)
 * [rls](https://github.com/rust-lang/rls)
-* [rustfmt](https://github.com/rust-lang/rustfmt)
 * All the external books
 
 These tools can be in one of the following states:

--- a/_data/latest.json
+++ b/_data/latest.json
@@ -14,13 +14,6 @@
         "datetime": "2021-04-25T01:57:28Z"
     },
     {
-        "tool": "rustfmt",
-        "windows": "build-fail",
-        "linux": "build-fail",
-        "commit": "b56b175c6c3d77f66793b2062b6325f822c87136",
-        "datetime": "2021-04-25T01:57:28Z"
-    },
-    {
         "tool": "book",
         "windows": "test-pass",
         "linux": "test-pass",


### PR DESCRIPTION
rustfmt will soon be a subtree instead of a submodule.

This should not be merged before https://github.com/rust-lang/rust/pull/82208.