### PR TITLE
Remove RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The latest status can be read from https://rust-lang-nursery.github.io/rust-tool
 Currently these tools are tracked:
 
 * [miri](https://github.com/rust-lang/miri)
-* [rls](https://github.com/rust-lang/rls)
 * All the external books
 
 These tools can be in one of the following states:

--- a/_data/latest.json
+++ b/_data/latest.json
@@ -7,13 +7,6 @@
         "datetime": "2022-08-27T00:38:19Z"
     },
     {
-        "tool": "rls",
-        "windows": "build-fail",
-        "linux": "build-fail",
-        "commit": "20ffea6938b5839c390252e07940b99e3b6a889a",
-        "datetime": "2022-08-11T20:49:35Z"
-    },
-    {
         "tool": "book",
         "windows": "test-pass",
         "linux": "test-pass",


### PR DESCRIPTION
RLS is no longer tracked in toolstate via https://github.com/rust-lang/rust/pull/100863.