### PR TITLE
remove Miri

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The latest status can be read from https://rust-lang-nursery.github.io/rust-tool
 
 Currently these tools are tracked:
 
-* [miri](https://github.com/rust-lang/miri)
 * All the external books
 
 These tools can be in one of the following states:

--- a/_data/latest.json
+++ b/_data/latest.json
@@ -1,12 +1,5 @@
 [
     {
-        "tool": "miri",
-        "windows": "build-fail",
-        "linux": "build-fail",
-        "commit": "11bb80a92b4f46fa7dfa9148d0bdfc185a7621bd",
-        "datetime": "2022-09-19T14:06:40Z"
-    },
-    {
         "tool": "book",
         "windows": "test-pass",
         "linux": "test-pass",


### PR DESCRIPTION
Once https://github.com/rust-lang/rust/pull/102028 lands, Miri will not be tracked by the toolstate system any more.